### PR TITLE
Move implicits to the companion objects where they belong

### DIFF
--- a/octopus/src/main/scala/octopus/DerivedAsyncValidator.scala
+++ b/octopus/src/main/scala/octopus/DerivedAsyncValidator.scala
@@ -3,11 +3,9 @@ package octopus
 import shapeless.labelled.FieldType
 import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness}
 
-import scala.language.higherKinds
-
 class DerivedAsyncValidator[M[_], T](val av: AsyncValidatorM[M, T]) extends AnyVal
 
-object DerivedAsyncValidator extends LowPriorityAsyncValidatorDerivation {
+object DerivedAsyncValidator {
 
   def apply[M[_]: AppError, T](av: AsyncValidatorM[M, T]): DerivedAsyncValidator[M, T] = new DerivedAsyncValidator[M, T](av)
 
@@ -40,10 +38,4 @@ object DerivedAsyncValidator extends LowPriorityAsyncValidatorDerivation {
         dav.value.av.validate(gen.to(obj))
       }
     }
-}
-
-trait LowPriorityAsyncValidatorDerivation extends Serializable{
-
-  implicit def fromSyncValidator[M[_]: AppError, T](implicit v: Validator[T]): DerivedAsyncValidator[M, T] =
-    DerivedAsyncValidator(AsyncValidatorM.lift(v))
 }

--- a/octopus/src/main/scala/octopus/DerivedValidator.scala
+++ b/octopus/src/main/scala/octopus/DerivedValidator.scala
@@ -6,41 +6,7 @@ import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, Inl, Inr, LabelledGener
 class DerivedValidator[T](val v: Validator[T]) extends AnyVal
 
 object DerivedValidator extends LowPriorityValidatorDerivation {
-
   def apply[T](v: Validator[T]): DerivedValidator[T] = new DerivedValidator[T](v)
-
-  implicit val stringValidator: DerivedValidator[String] = DerivedValidator(Validator[String])
-  implicit val intValidator: DerivedValidator[Int] = DerivedValidator(Validator[Int])
-  implicit val longValidator: DerivedValidator[Long] = DerivedValidator(Validator[Long])
-  implicit val boolValidator: DerivedValidator[Boolean] = DerivedValidator(Validator[Boolean])
-  implicit val doubleValidator: DerivedValidator[Double] = DerivedValidator(Validator[Double])
-  implicit val floatValidator: DerivedValidator[Float] = DerivedValidator(Validator[Float])
-  implicit val charValidator: DerivedValidator[Char] = DerivedValidator(Validator[Char])
-  implicit val byteValidator: DerivedValidator[Byte] = DerivedValidator(Validator[Byte])
-  implicit val shortValidator: DerivedValidator[Short] = DerivedValidator(Validator[Short])
-  implicit val unitValidator: DerivedValidator[Unit] = DerivedValidator(Validator[Unit])
-
-  implicit def optionValidator[T](implicit v: Validator[T]): DerivedValidator[Option[T]] = DerivedValidator {
-    (opt: Option[T]) => opt.map(v.validate).getOrElse(Nil)
-  }
-
-  implicit def IterableValidator[T, M[S] <: Iterable[S]](implicit v: Validator[T]): DerivedValidator[M[T]] = DerivedValidator {
-    (elems: M[T]) =>
-      elems.toList.zipWithIndex.flatMap { case (elem, idx) =>
-        v.validate(elem).map(CollectionIndex(idx) :: _)
-      }
-  }
-
-  implicit def arrayValidator[T](implicit tv: Validator[Iterable[T]]): DerivedValidator[Array[T]] = DerivedValidator {
-    (elems: Array[T]) => tv.validate(elems)
-  }
-
-  implicit def mapValidator[K, V](implicit v: Validator[V]): DerivedValidator[Map[K, V]] = DerivedValidator {
-    (map: Map[K, V]) =>
-      map.toList.flatMap { case (key, value) =>
-        v.validate(value).map(MapKey(key.toString) :: _)
-      }
-  }
 }
 
 trait LowPriorityValidatorDerivation extends Serializable{

--- a/octopus/src/main/scala/octopus/Validator.scala
+++ b/octopus/src/main/scala/octopus/Validator.scala
@@ -1,23 +1,42 @@
 package octopus
 
-trait Validator[T] extends Serializable{
-
+trait Validator[T] extends Serializable {
   def validate(obj: T): List[ValidationError]
 }
 
 object Validator extends Serializable {
 
-  def instance[T](f: T => List[ValidationError]): Validator[T] =
-    new Validator[T] {
-      def validate(obj: T): List[ValidationError] = f(obj)
+  def instance[T](f: T => List[ValidationError]): Validator[T] = f(_)
+  def apply[T]: Validator[T] = _ => Nil
+  def invalid[T](error: String): Validator[T] = _ => List(ValidationError(error))
+  def derived[T](implicit dv: DerivedValidator[T]): Validator[T] = dv.v
+
+  implicit val stringValidator: Validator[String] = Validator[String]
+  implicit val intValidator: Validator[Int] = Validator[Int]
+  implicit val longValidator: Validator[Long] = Validator[Long]
+  implicit val boolValidator: Validator[Boolean] = Validator[Boolean]
+  implicit val doubleValidator: Validator[Double] = Validator[Double]
+  implicit val floatValidator: Validator[Float] = Validator[Float]
+  implicit val charValidator: Validator[Char] = Validator[Char]
+  implicit val byteValidator: Validator[Byte] = Validator[Byte]
+  implicit val shortValidator: Validator[Short] = Validator[Short]
+  implicit val unitValidator: Validator[Unit] = Validator[Unit]
+
+  implicit def optionValidator[T](implicit v: Validator[T]): Validator[Option[T]] =
+    _.fold(List.empty[ValidationError])(v.validate)
+
+  implicit def iterableValidator[T, M[S] <: Iterable[S]](implicit v: Validator[T]): Validator[M[T]] =
+    _.toList.zipWithIndex.flatMap { case (elem, idx) =>
+      v.validate(elem).map(CollectionIndex(idx) :: _)
     }
 
-  def apply[T]: Validator[T] = (_: T) => Nil
+  implicit def arrayValidator[T](implicit tv: Validator[Iterable[T]]): Validator[Array[T]] =
+    tv.validate(_)
 
-  def invalid[T](error: String): Validator[T] = (_: T) => List(ValidationError(error))
-
-  def derived[T](implicit dv: DerivedValidator[T]): Validator[T] =
-    dv.v
+  implicit def mapValidator[K, V](implicit v: Validator[V]): Validator[Map[K, V]] =
+    _.toList.flatMap { case (key, value) =>
+      v.validate(value).map(MapKey(key.toString) :: _)
+    }
 
   implicit def fromDerivedValidator[T](implicit dv: DerivedValidator[T]): Validator[T] = dv.v
 }


### PR DESCRIPTION
This fixes the performance issues on Scala 2.13.